### PR TITLE
feat: EC2 운영 환경에서 백엔드/프론트엔드 로그를 호스트 디렉토리에 보존

### DIFF
--- a/backend/content-hub-backend/content-hub/src/main/resources/environment/application-prod.yml
+++ b/backend/content-hub-backend/content-hub/src/main/resources/environment/application-prod.yml
@@ -56,11 +56,20 @@ server:
 
 # Log Config
 logging:
+  file:
+    name: /app/logs/app.log
   level:
     root: INFO
     com:
       cjy:
         contenthub: INFO
+  logback:
+    rollingpolicy:
+      max-file-size: 100MB
+      max-history: 30
+      total-size-cap: 3GB
+      clean-history-on-start: false # 어플리케이션 시작 시 로그 파일 클리어 설정
+      file-name-pattern: ${LOG_FILE}.%d{yyyy-MM-dd}.%i.gz
 
 # Actuator Config
 management:

--- a/backend/content-hub-backend/content-hub/src/main/resources/environment/application-staging.yml
+++ b/backend/content-hub-backend/content-hub/src/main/resources/environment/application-staging.yml
@@ -56,11 +56,20 @@ server:
 
 # Log Config
 logging:
+  file:
+    name: /app/logs/app.log
   level:
     root: INFO
     com:
       cjy:
         contenthub: DEBUG  # QA 편의상 애플리케이션만 DEBUG
+  logback:
+    rollingpolicy:
+      max-file-size: 100MB
+      max-history: 30
+      total-size-cap: 3GB
+      clean-history-on-start: false # 어플리케이션 시작 시 로그 파일 클리어 설정
+      file-name-pattern: ${LOG_FILE}.%d{yyyy-MM-dd}.%i.gz
 
 # Actuator Config
 management:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -10,11 +10,16 @@ services:
        - /var/www/certbot:/var/www/certbot
        # Let's Encrypt에서 발급받은 실제 SSL 인증서 파일들이 저장되는 핵심 디렉토리(ro:Read Only)
        - /etc/letsencrypt:/etc/letsencrypt:ro
+       # 로그 추가
+       - ./logs/frontend:/var/log/nginx
   backend:
     env_file:
       - ./backend/env/.env.prod
     ports: []
     restart: "no"
+    volumes:
+      # 로그 추가
+      - ./logs/backend:/app/logs
     healthcheck:
       test: ["CMD-SHELL","curl -f http://localhost:8081/actuator/health || exit 1"]
       interval: 30s


### PR DESCRIPTION
## 관련 이슈
Closes #3

## 변경 내용
### 프론트엔드
공통:
1. 인프라
- docker-compose volume 설정으로 백엔드/프론트엔드 컨테이너 로그를 호스트에 보존

백엔드:
1. 공통
- application-prod.yml, application-staging.yml 변경
  - 로그 보존 디렉토리 변경
  - 로그 파일 최대 크기, 최대 보관 기간, 전체 용량 제한, 시작 시 정리 여부, 파일 이름 패턴 설정

## 테스트 완료 항목
- [x] 로컬 환경 테스트
- [x] 기존 기능 영향 없음 확인

### 운영 환경
- 프론트엔드 Nginx 로그 로테이션 설정
```
1. logrotate 설정 파일 생성
# EC2 서버에서 logrotate 설정 파일 생성
sudo vi /etc/logrotate.d/nginx-frontend

# /etc/logrotate.d/nginx-frontend
/app/logs/frontend/*. log {
    # 일별 로테이션
    daily
    
    # 30일간 보관
    rotate 30
    
    # 100MB 넘으면 즉시 로테이션
    size 100M
    
    # 로그 파일이 없어도 에러 안 냄
    missingok
    
    # 빈 로그 파일은 로테이션 안 함
    notifempty
    
    # gzip 압축
    compress
    
    # 가장 최근 파일은 압축 안 함 (현재 사용 중)
    delaycompress
    
    # 로그 파일 소유자/권한 유지
    create 0640 www-data www-data
    
    # 날짜 형식으로 파일명 생성
    dateext
    dateformat -%Y%m%d
    
    # Nginx 재시작 없이 로그 파일 재오픈
    sharedscripts
    postrotate
        # Nginx에 USR1 시그널 전송 (로그 재오픈)
        if [ -f /var/run/nginx.pid ]; then
            kill -USR1 `cat /var/run/nginx.pid`
        fi
    endscript
    
    # 전체 용량 제한 (3GB)
    # logrotate에는 직접 지원 안 함, maxage로 대체
    maxage 30
}

2. 권한 설정
# 설정 파일 권한
sudo chmod 644 /etc/logrotate.d/nginx-frontend

# 로그 디렉토리 소유권(/home/ubuntu/app/logs/frontend 디렉터리와 그 하위 파일들(재귀적 -Reculsive)의 소유자(Owner)와 그룹(Group)을 모두 www-data로 변경)
# 이유: Nginx가 이 경로에 로그 파일을 생성하거나 롤링된 파일을 압축할 때 권한 문제가 발생하지 않도록 하기 위함
sudo chown -R www-data:www-data /home/ubuntu/app/logs/frontend

# 로그 디렉토리 권한(/home/ubuntu/app/logs/frontend 디렉터리의 권한을 755로 설정)
# 755 권한: 소유자 (www-data): 읽기, 쓰기, 실행 가능 (7) / 그룹 (www-data): 읽기, 실행 가능 (5) / 기타 사용자 (Others): 읽기, 실행 가능 (5)
# 이유: 소유자는 로그 파일을 생성하고 수정, 실행 권한(x)은 디렉터리 내부에 접근할 수 있는 권한을 의미하며, logrotate나 다른 시스템 프로세스가 해당 디렉터리를 탐색할 수 있도록 허용
sudo chmod 755 /home/ubuntu/app/logs/frontend

## ubuntu 유저가 로그 볼 수 있게 www-data 그룹에 추가
sudo usermod -aG www-data ubuntu
# 새로운 그룹 반영
newgrp www-data
# 확인
id ubuntu

# 현재 로그 파일 권한 설정
sudo chmod 640 /home/ubuntu/app/logs/frontend/*. log
# 파일의 주인(Owner)과 그룹(Group)을 모두 www-data(Nginx 실행 계정)로 변경
sudo chown www-data:www-data /home/ubuntu/app/logs/frontend/*.log

# 로테이션된(과거) 로그 파일 권한 설정(644로 기타 사용자도 읽기 가능)
sudo chmod 644 /home/ubuntu/app/logs/frontend/*.log-*
```

## 배포 후 검증 계획
1. 운영 환경에 배포가 완료된 후, EC2 인스턴스에 접속
2. `docker-compose.yml`에 설정된 호스트 볼륨 경로로 이동 (예: `/home/ubuntu/app/logs/` )
3. `ls -l` 명령어를 실행하여 백엔드와 프론트엔드의 로그 파일이 정상적으로 생성되었는지 확인
4. `tail -f [로그 파일명]` 명령어를 실행하여 실시간으로 로그가 쌓이는 것을 확인

## 스크린샷
<img width="2248" height="1293" alt="image" src="https://github.com/user-attachments/assets/5ef9ed3a-ed80-4419-8488-dbdf013d6e34" />
