### PR TITLE
feat: 모든 하위 디렉터리에서 확장자가 .map인 파일을 삭제하도록 변경

### DIFF
--- a/frontend/content-hub-frontend/Dockerfile
+++ b/frontend/content-hub-frontend/Dockerfile
@@ -23,8 +23,9 @@ RUN npm rebuild esbuild --update-binary || true
 ENV NODE_OPTIONS=--max-old-space-size=4096
 RUN npm run build
 
-# build 후 dist 폴더에서 .map 파일 삭제
+# build 후 dist 폴더에서 .map 파일 삭제(Sentry sourcemap 업로드 실패 시 sourcemap이 삭제되지 않는 경우를 방지)
 RUN find ./dist -name "*.map" -type f -delete
+
 
 # Stage 2 Nginx to serve static files
 # nginx 빌드 환경 설정

--- a/frontend/content-hub-frontend/vite.config.ts
+++ b/frontend/content-hub-frontend/vite.config.ts
@@ -22,7 +22,7 @@ export default defineConfig(({ mode }) => {
           authToken: process.env.SENTRY_AUTH_TOKEN, // process.env.SENTRY_AUTH_TOKEN은 빌드 시점에만 접근 가능, CI/CD 환경변수에서 설정
           sourcemaps: {
             assets: ['./dist/assets/**'], // sourcemap 업로드할 파일 경로
-            filesToDeleteAfterUpload: ['./dist/assets/**.map'], // 업로드 후 삭제할 sourcemap 파일 경로
+            filesToDeleteAfterUpload: ['./dist/assets/**/*.map'], // 업로드 후 삭제할 sourcemap 파일 경로
           },
         }),
     ],


### PR DESCRIPTION
## 관련 이슈
Closes #9 

## 변경 내용
### 프론트엔드:
1. 공통
- 소스맵 삭제 경로 ./dist/assets/**.map → ./dist/assets/**/*.map 으로 변경 
  → 향후 하위 폴더에 생성될 수 있는 .map 파일까지 누락 없이 삭제
- Dockerfile 에 소스맵 삭제 명령어에 "(Sentry sourcemap 업로드 실패 시 sourcemap이 삭제되지 않는 경우를 방지)" 주석 추가

## 테스트 완료 항목
- [x] 로컬 환경 테스트
- [x] 기존 기능 영향 없음 확인

## 참고사항
- #10 리뷰 지적 대응
