### PR TITLE
fix: 운영환경에서 actuator 접속 불가 수정, restart 값 및 포트 노출 재설정

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -16,7 +16,7 @@ services:
     env_file:
       - ./backend/env/.env.prod
     ports:
-      - "8080:8080"    # 메인 서비스(외부, Nginx 등에서 접근)
+      #- "8080:8080"    # 메인 서비스(외부, Nginx 등에서 접근) → 필요 시에만 외부 노출
       - "8081:8081"    # Actuator 등 운영관리용
     restart: "unless-stopped"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,8 +41,10 @@ services:
       - ./backend/env/.env.prod
     volumes:
       - pgdata:/var/lib/postgresql/data
-    ports:
-      - "5432:5432"
+    expose:
+      - "5432"   # 내부 네트워크에서만
+    #ports:
+    #  - "5432:5432"  # 필요 시에만 외부 노출
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB -h localhost -p 5432"]
       interval: 5s
@@ -58,8 +60,10 @@ services:
   redis:
     image: redis:latest
     container_name: redis
-    ports:
-      - "6379:6379"
+    expose:
+      - "6379"   # 내부 네트워크에서만
+    #ports:
+    #  - "6379:6379"  # 필요 시에만 외부 노출
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s


### PR DESCRIPTION
## 관련 이슈
Closes #12 

## 발생 원인 (이슈 타입이 BUG인 경우)
### 직접 원인
- docker-compose 에서 8081 포트가 호스트에 노출되지 않음
### 근본 원인
- 최초 docker-compose 구성 시, 8081 포트 노출 누락

## 해결 방안 (이슈 타입이 BUG인 경우)
- docker-compose에서 호스트에 8081 포트 노출

## 변경 내용
### 공통
1. 인프라
- docker-compose.yml 수정
  - db, redis 포트 외부 노출 명시적 제거 (외부 접속 방지 및 보안 강화) (feat)
  - 주석 보강 (chore)
- docker-compose.override.yml 수정
  - ports 에 8081 포트 노출 설정 추가 (운영환경에서 actuator 정상 접속 목적) (fix)
  - backend 포트 외부 노출 명시적 제거 (외부 접속 방지 및 보안 강화) (feat)
  - restart: "unless-stopped" 설정 변경 (예상치 못한 컨테이너 중단 시 자동 복구) (feat)

## 테스트 완료 항목
- [x] 로컬 환경 테스트
- [x] 기존 기능 영향 없음 확인

## 배포 후 검증 계획
1. powershell에서 EC2 터미널 접속 (접속 방법은 Wiki 확인)
3. actuator 접속 명령어 실행
→ curl http://127.0.0.1:8081/actuator/health

## 로그
```
{"status":"UP","groups":["liveness","readiness"]}
```

## 참고사항
- 추가 대응 사항
  - db, redis, backend 포트 외부 노출 제거
  - restart 설정이 "no"로 되어 있어서 restart: "unless-stopped" 설정 변경
