### PR TITLE
feat: 로그인 보안 취약점 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ replay_pid*
 /backend/**/.env.dev
 /backend/**/.env.staging
 /backend/**/application-secret.yml
+/backend/redis/data/
 
 # 예외 설정: gradlew Wrapper jar 파일은 포함
 !/backend/**/gradle/wrapper/gradle-wrapper.jar 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,6 +1,8 @@
 
 services:
   frontend:
+    environment:
+      - TZ=Asia/Seoul
     ports:
       - "80:80"
       - "443:443"          # HTTPS 외부 노출
@@ -13,6 +15,8 @@ services:
        # 로그 추가
        - ./logs/frontend:/var/log/nginx
   backend:
+    environment:
+      - TZ=Asia/Seoul
     env_file:
       - ./backend/env/.env.prod
     ports:
@@ -29,8 +33,12 @@ services:
       retries: 3
       start_period: 40s
   db:
+    environment:
+      - TZ=Asia/Seoul
     ports: []            # 외부 노출 제거
     restart: "unless-stopped"
   redis:
+    environment:
+      - TZ=Asia/Seoul
     ports: []            # 외부 노출 제거
     restart: "unless-stopped"

--- a/frontend/content-hub-frontend/nginx.conf
+++ b/frontend/content-hub-frontend/nginx.conf
@@ -8,7 +8,9 @@ server {
     }
 
     # 모든 HTTP 요청을 HTTPS로 영구 리다이렉트
-    rewrite ^ https://$host$request_uri? permanent;
+	location / {
+        return 301 https://$host$request_uri;
+    }
 }
 
 server {
@@ -36,7 +38,9 @@ server {
     ssl_session_timeout 1h;
 
     # 보안 헤더
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    # 공통 헤더를 변수로 설정하여 재사용
+    set $common_csp "default-src 'self'; connect-src 'self' https://*.sentry.io; img-src 'self' data: https://*.anilist.co https://image.tmdb.org; script-src 'self' 'unsafe-inline' blob:; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:;";
+    set $common_hsts "max-age=31536000; includeSubDomains";
 	
 	# gzip 압축
     gzip on;
@@ -50,15 +54,19 @@ server {
 		
 	# 1순위: 정적 자산(JS, CSS 등) 효율적인 캐싱 적용 (파일명 해시 활용한 캐싱)
 	location /assets/ {
-	    expires 1y;
+		add_header Content-Security-Policy $common_csp always;
+        add_header Strict-Transport-Security $common_hsts always;
         add_header Cache-Control "public, immutable"; # 파일명이 안바뀌면 계속 캐시 사용
+        expires 1y;
         try_files $uri =404;
     }
 	
 	# 2순위: 기타 정적 파일 확장자 처리
     location ~* \.(js|css|map|json|png|jpg|jpeg|gif|svg|webp|ico)$ {
-	    expires 1y;
+        add_header Content-Security-Policy $common_csp always;
+        add_header Strict-Transport-Security $common_hsts always;
         add_header Cache-Control "public, immutable";
+	    expires 1y;
         try_files $uri =404;
     }
 
@@ -77,6 +85,9 @@ server {
 	
 	# 5순위: index.html 및 루트 경로: 캐싱 방지 설정 / 프론트 라우팅 해결 (SPA)
     location / {
+	# 운영 환경용 CSP 헤더
+        add_header Content-Security-Policy $common_csp always;
+        add_header Strict-Transport-Security $common_hsts always;
         add_header Cache-Control "no-cache, no-store, must-revalidate";
         add_header Pragma "no-cache";
         add_header Expires 0;

--- a/frontend/content-hub-frontend/nginx.conf
+++ b/frontend/content-hub-frontend/nginx.conf
@@ -41,12 +41,16 @@ server {
     # 공통 헤더를 변수로 설정하여 재사용
     set $common_csp "default-src 'self'; connect-src 'self' https://*.sentry.io; img-src 'self' data: https://*.anilist.co https://image.tmdb.org; script-src 'self' 'unsafe-inline' blob:; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:;";
     set $common_hsts "max-age=31536000; includeSubDomains";
+
+    # 모든 응답에 적용
+    add_header Content-Security-Policy $common_csp always; # 운영 환경용 CSP 헤더
+    add_header Strict-Transport-Security $common_hsts always; # HSTS(HTTPS 강제 적용) 헤더
 	
-	# gzip 압축
-    gzip on;
-    gzip_types text/plain text/css application/json application/javascript text/xml application/xml text/javascript;
-    gzip_vary on;
-    gzip_min_length 1024;
+	# gzip 압축(효율적인 데이터 전송 위해)
+    gzip on; # gzip 압축 활성화
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml text/javascript; # 압축할 MIME 타입 지정(텍스트 기반 파일 위주)
+    gzip_vary on; # 클라이언트가 gzip을 지원하는지에 따라 압축된 응답 제공
+    gzip_min_length 1024; # 최소 압축 대상 크기 설정(1KB 이상인 경우에만 압축)
 
     # React 정적 파일
     root /usr/share/nginx/html;
@@ -85,12 +89,12 @@ server {
 	
 	# 5순위: index.html 및 루트 경로: 캐싱 방지 설정 / 프론트 라우팅 해결 (SPA)
     location / {
-	# 운영 환경용 CSP 헤더
-        add_header Content-Security-Policy $common_csp always;
-        add_header Strict-Transport-Security $common_hsts always;
-        add_header Cache-Control "no-cache, no-store, must-revalidate";
-        add_header Pragma "no-cache";
-        add_header Expires 0;
+        add_header Content-Security-Policy $common_csp always; # 운영 환경용 CSP 헤더
+        add_header Strict-Transport-Security $common_hsts always; # HSTS 헤더
+        # 항상 최신 버전의 웹사이트를 볼 수 있도록 캐싱 방지
+        add_header Cache-Control "no-cache, no-store, must-revalidate"; # 캐싱 방지
+        add_header Pragma "no-cache"; # 구 버전 HTTP/1.0 캐싱 방지
+        add_header Expires 0; # 즉시 만료시켜 캐싱 방지
 		
 		root /usr/share/nginx/html; # 프론트엔드 빌드 결과물 경로
 		index index.html;

--- a/frontend/content-hub-frontend/src/api/http-client.ts
+++ b/frontend/content-hub-frontend/src/api/http-client.ts
@@ -26,6 +26,7 @@ import type {
   ResponseType,
 } from 'axios'; // add custom config
 import axios from 'axios';
+import { useUserStore } from '@/components/common/store/globalStateStore'; // add custom config
 
 export type QueryParamsType = Record<string | number, any>;
 
@@ -214,7 +215,7 @@ export class HttpClient<SecurityDataType = unknown> {
       body = JSON.stringify(body);
     }
 
-    const jwt = sessionStorage.getItem('jwt'); // add custom config
+    const jwt = useUserStore.getState().jwt; // add custom config
     const xsrfToken = getXsrfTokenFromCookie(); // add custom config
     return this.instance.request({
       ...requestParams,

--- a/frontend/content-hub-frontend/src/components/common/interceptor/httpClientInterceptors.test.ts
+++ b/frontend/content-hub-frontend/src/components/common/interceptor/httpClientInterceptors.test.ts
@@ -38,7 +38,7 @@ vi.mock('@/components/common/utils/clearUtil', () => ({
   clearUserData: vi.fn(),
 }));
 
-describe('HttpClient Request Interceptors(NAVER)', () => {
+describe('httpClientRequestInterceptor(NAVER)', () => {
   beforeEach(() => {
     // 초기 상태 설정
     useUserStore.setState({
@@ -46,6 +46,9 @@ describe('HttpClient Request Interceptors(NAVER)', () => {
         name: 'name',
         nickname: 'nickname',
       },
+      accessToken: 'access_token',
+      jwt: 'jwt',
+      expireDate: dayjs().subtract(1, 'hour').toISOString(), // 만료된 토큰
       clearUser: vi.fn(),
     });
     useProviderStore.setState({
@@ -90,21 +93,13 @@ describe('HttpClient Request Interceptors(NAVER)', () => {
   });
 
   it('JWT 만료 시 네이버 로그인 업데이트 API 호출', async () => {
-    // 세션 초기화 및 만료된 JWT 설정
-    sessionStorage.setItem('accessToken', 'old-access');
-    sessionStorage.setItem('jwt', 'old-jwt');
-    sessionStorage.setItem(
-      'expireDate',
-      dayjs().subtract(1, 'hour').toISOString()
-    ); // 만료됨
-
-    // 새로운 토큰 정보 모의 응답 설정
+    // 새로운 토큰 정보
     const mockNewToken = {
       accessToken: 'new-access',
       jwt: 'new-jwt',
       expireDate: dayjs().add(1, 'hour').toISOString(), //
     };
-
+    // 모의 응답 설정
     const axiosMock = vi.spyOn(axios, 'get').mockResolvedValueOnce({
       data: mockNewToken,
     });
@@ -129,13 +124,7 @@ describe('HttpClient Request Interceptors(NAVER)', () => {
   });
 
   it('JWT 만료 시 로그인 업데이트 API 호출 실패 시 clearUserData 호출', async () => {
-    // 세션 초기화 및 만료된 JWT 설정
-    sessionStorage.setItem('accessToken', 'old-access');
-    sessionStorage.setItem('jwt', 'old-jwt');
-    sessionStorage.setItem(
-      'expireDate',
-      dayjs().subtract(1, 'hour').toISOString()
-    ); // 만료됨
+    // 모의 응답 설정
     const axiosMock = vi.spyOn(axios, 'get').mockResolvedValueOnce({
       data: null,
     });
@@ -159,13 +148,7 @@ describe('HttpClient Request Interceptors(NAVER)', () => {
   });
 
   it('로그인 갱신 API 호출 중 에러 발생 시 clearUserData 호출', async () => {
-    // 세션 초기화 및 만료된 JWT 설정
-    sessionStorage.setItem('accessToken', 'old-access');
-    sessionStorage.setItem('jwt', 'old-jwt');
-    sessionStorage.setItem(
-      'expireDate',
-      dayjs().subtract(1, 'hour').toISOString()
-    ); // 만료됨
+    // 모의 응답 설정
     const axiosMock = vi.spyOn(axios, 'get').mockRejectedValueOnce(new Error('Network Error'));
     const requestUrl = '/api/home/rankings';
     const requestConfig = {
@@ -187,21 +170,13 @@ describe('HttpClient Request Interceptors(NAVER)', () => {
   });
 
   it('로그인 갱신 중복 방지 확인', async () => {
-    // 세션 초기화 및 만료된 JWT 설정
-    sessionStorage.setItem('accessToken', 'old-access');
-    sessionStorage.setItem('jwt', 'old-jwt');
-    sessionStorage.setItem(
-      'expireDate',
-      dayjs().subtract(1, 'hour').toISOString()
-    ); // 만료됨
-
-    // 새로운 토큰 정보 모의 응답 설정
+    // 새로운 토큰 정보
     const mockNewToken = {
       accessToken: 'new-access',
       jwt: 'new-jwt',
       expireDate: dayjs().add(1, 'hour').toISOString(), //
     };
-
+    // 모의 응답 설정
     const axiosMock = vi.spyOn(axios, 'get').mockResolvedValue({
       data: mockNewToken,
     });
@@ -228,7 +203,7 @@ describe('HttpClient Request Interceptors(NAVER)', () => {
 
 });
 
-describe('HttpClient Request Interceptors(KAKAO)', () => {
+describe('httpClientRequestInterceptor(KAKAO)', () => {
   beforeEach(() => {
     // 초기 상태 설정
     useUserStore.setState({
@@ -247,21 +222,13 @@ describe('HttpClient Request Interceptors(KAKAO)', () => {
   });
 
   it('JWT 만료 시 카카오 로그인 업데이트 API 호출', async () => {
-    // 세션 초기화 및 만료된 JWT 설정
-    sessionStorage.setItem('accessToken', 'old-access');
-    sessionStorage.setItem('jwt', 'old-jwt');
-    sessionStorage.setItem(
-      'expireDate',
-      dayjs().subtract(1, 'hour').toISOString()
-    ); // 만료됨
-
-    // 새로운 토큰 정보 모의 응답 설정
+    // 새로운 토큰 정보
     const mockNewToken = {
       accessToken: 'new-access',
       jwt: 'new-jwt',
       expireDate: dayjs().add(1, 'hour').toISOString(), //
     };
-
+    // 모의 응답 설정
     const axiosMock = vi.spyOn(axios, 'get').mockResolvedValueOnce({
       data: mockNewToken,
     });
@@ -287,7 +254,7 @@ describe('HttpClient Request Interceptors(KAKAO)', () => {
   });
 });
 
-describe('HttpClient Response Interceptors', () => {
+describe('httpClientResponseInterceptor', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     sessionStorage.clear();
@@ -311,7 +278,9 @@ describe('HttpClient Response Interceptors', () => {
       expect(mockResponse.data).toEqual({ message: 'success' });
     });
   });
+});
 
+describe('httpClientResponseErrorInterceptor', () => {
   it('401 응답 시 인터셉터가 에러를 감지하고 데이터를 비우는지 확인', async () => {
     const mockError = {
       response: {

--- a/frontend/content-hub-frontend/src/components/common/interceptor/httpClientInterceptors.test.ts
+++ b/frontend/content-hub-frontend/src/components/common/interceptor/httpClientInterceptors.test.ts
@@ -38,6 +38,10 @@ vi.mock('@/components/common/utils/clearUtil', () => ({
   clearUserData: vi.fn(),
 }));
 
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
 describe('httpClientRequestInterceptor(NAVER)', () => {
   beforeEach(() => {
     // 초기 상태 설정
@@ -83,6 +87,11 @@ describe('httpClientRequestInterceptor(NAVER)', () => {
       method: 'GET',
       headers: {},
     } as InternalAxiosRequestConfig;
+
+    // JWT 제거
+    useUserStore.setState({
+      jwt: null,
+    });
 
     // 실제 인터셉터 호출
     httpClientRequestInterceptor(requestConfig, axios);
@@ -157,15 +166,22 @@ describe('httpClientRequestInterceptor(NAVER)', () => {
       headers: {},
     } as InternalAxiosRequestConfig;
 
-    // 실제 인터셉터 호출
-    httpClientRequestInterceptor(requestConfig, axios);
+    // 콘솔 에러 모킹
+    const consoleErrorMock = vi.spyOn(console, 'error');
 
+    // 실제 인터셉터 호출
+    await httpClientRequestInterceptor(requestConfig, axios);
+
+    // 검증
     await waitFor(() => {
-      // 검증
       expect(axiosMock).toHaveBeenCalledWith(
         expect.stringContaining('/api/login/updateNaverLoginInfo')
       );
       expect(clearUserData).toHaveBeenCalled();
+      expect(consoleErrorMock).toHaveBeenCalledWith(
+        '토큰 갱신 처리 중 에러 발생: ',
+        expect.any(Error)
+      );
     });
   });
 
@@ -211,6 +227,9 @@ describe('httpClientRequestInterceptor(KAKAO)', () => {
         name: 'name',
         nickname: 'nickname',
       },
+      accessToken: 'access_token',
+      jwt: 'jwt',
+      expireDate: dayjs().subtract(1, 'hour').toISOString(), // 만료된 토큰
       clearUser: vi.fn(),
     });
     useProviderStore.setState({
@@ -250,6 +269,87 @@ describe('httpClientRequestInterceptor(KAKAO)', () => {
       );
       expect(setLoginInfo).toHaveBeenCalledWith(mockNewToken, 'KAKAO');
       expect(result.headers.Authorization).toBe('Bearer new-jwt');
+    });
+  });
+});
+
+describe('httpClientRequestInterceptor(토큰 만료 아님)', () => {
+  beforeEach(() => {
+    // 초기 상태 설정
+    useUserStore.setState({
+      user: {
+        name: 'name',
+        nickname: 'nickname',
+      },
+      accessToken: 'access-token',
+      jwt: 'jwt',
+      expireDate: dayjs().add(1, 'hour').toISOString(), // 만료되지 않은 토큰
+      clearUser: vi.fn(),
+    });
+    useProviderStore.setState({
+      provider: 'NAVER',
+    });
+  });
+
+  it('토큰 만료되지 않았을 때는 토큰 갱신 로직 스킵', async () => {
+    const requestUrl = '/api/home/rankings';
+    const requestConfig = {
+      url: requestUrl,
+      method: 'GET',
+      headers: {},
+    } as InternalAxiosRequestConfig;
+    // 토큰 정보
+    const mockToken = {
+      accessToken: 'access-token',
+      jwt: 'jwt',
+      expireDate: dayjs().add(1, 'hour').toISOString(), // 만료되지 않음
+    };
+    // 모의 응답 설정
+    const axiosMock = vi.spyOn(axios, 'get').mockResolvedValueOnce({
+      data: mockToken,
+    });
+    // 실제 인터셉터 호출
+    await httpClientRequestInterceptor(requestConfig, axios);
+    // 검증
+    await waitFor(() => {
+      expect(axiosMock).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('httpClientRequestInterceptor(UNKNOWN 프로바이더)', () => {
+  beforeEach(() => {
+    // 초기 상태 설정
+    useUserStore.setState({
+      user: {
+        name: 'name',
+        nickname: 'nickname',
+      },
+      accessToken: 'access-token',
+      jwt: 'jwt',
+      expireDate: dayjs().subtract(1, 'hour').toISOString(), // 만료된 토큰
+      clearUser: vi.fn(),
+    });
+    useProviderStore.setState({
+      provider: 'UNKNOWN', // 네이버/카카오 이외의 프로바이더
+    });
+  });
+
+  it('네이버/카카오 이외의 프로바이더일 때 토큰 갱신 로직 스킵', async () => {
+    const requestUrl = '/api/home/rankings';
+    const requestConfig = {
+      url: requestUrl,
+      method: 'GET',
+      headers: {},
+    } as InternalAxiosRequestConfig;
+
+    // 실제 인터셉터 호출
+    await httpClientRequestInterceptor(requestConfig, axios);
+
+    await waitFor(() => {
+      expect(requestConfig).toBeDefined();
+      expect(requestConfig.url).toBe(requestUrl);
+      expect(clearUserData).toHaveBeenCalledTimes(1);
     });
   });
 });
@@ -328,6 +428,30 @@ describe('httpClientResponseErrorInterceptor', () => {
 
     await waitFor(() => {
       expect(clearUserData).toHaveBeenCalled();
+    });
+  });
+
+  it('다른 에러 응답 시에는 clearUserData가 호출되지 않는지 확인', async () => {
+    const mockError = {
+      response: {
+        data: {
+          status: 500,
+          message: 'Internal Server Error',
+          name: 'InternalServerError',
+        },
+        config: {
+          url: '/api/home/rankings',
+          method: 'GET',
+          headers: {},
+        },
+      },
+    } as AxiosError<AxiosErrorType>;
+
+    // 실제 인터셉터 호출
+    await httpClientResponseErrorInterceptor(mockError);
+
+    await waitFor(() => {
+      expect(clearUserData).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/content-hub-frontend/src/components/common/interceptor/httpClientInterceptors.ts
+++ b/frontend/content-hub-frontend/src/components/common/interceptor/httpClientInterceptors.ts
@@ -12,7 +12,6 @@ import { clearUserData } from '../utils/clearUtil';
 import { AxiosErrorType } from '../config/queryClientConfig';
 import { useProviderStore, useUserStore } from '../store/globalStateStore';
 import { setLoginInfo } from '../utils/loginUtil';
-import { toast } from 'react-toastify';
 
 // Sentry 동적 import
 const Sentry = import('@sentry/react');
@@ -79,13 +78,6 @@ export const httpClientRequestInterceptor = async (
         // 유저정보 클리어
         clearUserData();
         console.error('토큰 갱신 처리 중 에러 발생: ', error);
-        toast.error('로그인이 만료되었습니다. 다시 로그인 해주세요.', {
-          toastId: 'tokenRefreshError',
-        });
-        // 2초 정도 대기 후 페이지 이동 (사용자가 읽을 시간 확보)
-        setTimeout(() => {
-          globalThis.location.href = '/login';
-        }, 2000);
       }
       finally {
         // 토큰 갱신 Promise 초기화

--- a/frontend/content-hub-frontend/src/components/common/interceptor/httpClientInterceptors.ts
+++ b/frontend/content-hub-frontend/src/components/common/interceptor/httpClientInterceptors.ts
@@ -12,6 +12,7 @@ import { clearUserData } from '../utils/clearUtil';
 import { AxiosErrorType } from '../config/queryClientConfig';
 import { useProviderStore, useUserStore } from '../store/globalStateStore';
 import { setLoginInfo } from '../utils/loginUtil';
+import { toast } from 'react-toastify';
 
 // Sentry 동적 import
 const Sentry = import('@sentry/react');
@@ -30,20 +31,16 @@ export const httpClientRequestInterceptor = async (
   if (request.url?.startsWith('/api/login/')) {
     return request;
   }
-  // 유저정보
-  const { user } = useUserStore.getState();
+  // 유저정보, JWT, 만료시각
+  const { user, jwt, expireDate } = useUserStore.getState();
   // provider 정보
   const { provider } = useProviderStore.getState();
-  // 접근토큰
-  const jwt = sessionStorage.getItem('jwt');
-  // 접근토큰이 없고 유저정보가 있는 경우 처리 종료
+  // JWT가 없고 유저정보가 있는 경우 처리 종료
   if (!jwt && user) {
     // 유저정보 클리어
     clearUserData();
     return request;
   }
-  // 만료시각
-  const expireDate = sessionStorage.getItem('expireDate');
   // 현재시각
   const now = dayjs();
   // 접근토큰 만료 확인
@@ -82,6 +79,13 @@ export const httpClientRequestInterceptor = async (
         // 유저정보 클리어
         clearUserData();
         console.error('토큰 갱신 처리 중 에러 발생: ', error);
+        toast.error('로그인이 만료되었습니다. 다시 로그인 해주세요.', {
+          toastId: 'tokenRefreshError',
+        });
+        // 2초 정도 대기 후 페이지 이동 (사용자가 읽을 시간 확보)
+        setTimeout(() => {
+          globalThis.location.href = '/login';
+        }, 2000);
       }
       finally {
         // 토큰 갱신 Promise 초기화

--- a/frontend/content-hub-frontend/src/components/common/store/globalStateStore.test.ts
+++ b/frontend/content-hub-frontend/src/components/common/store/globalStateStore.test.ts
@@ -16,7 +16,12 @@ import {
 } from '@/api/data-contracts';
 
 describe('useUserStore', () => {
-  beforeEach(() => useUserStore.setState({ user: null }));
+  beforeEach(() => useUserStore.setState({ 
+    user: null,
+    accessToken: null,
+    jwt: null,
+    expireDate: null,
+  }));
   it('초기값은 user: null', () => {
     expect(useUserStore.getState().user).toBeNull();
   });
@@ -42,6 +47,9 @@ describe('useUserStore', () => {
     useUserStore.getState().setUser({ userId: 1 } as LoginUserInfoDto);
     useUserStore.getState().clearUser();
     expect(useUserStore.getState().user).toBeNull();
+    expect(useUserStore.getState().accessToken).toBeNull();
+    expect(useUserStore.getState().jwt).toBeNull();
+    expect(useUserStore.getState().expireDate).toBeNull();
   });
 });
 

--- a/frontend/content-hub-frontend/src/components/common/store/globalStateStore.test.ts
+++ b/frontend/content-hub-frontend/src/components/common/store/globalStateStore.test.ts
@@ -25,6 +25,19 @@ describe('useUserStore', () => {
     useUserStore.getState().setUser(dummyUser);
     expect(useUserStore.getState().user).toEqual(dummyUser);
   });
+  it('setAccessToken로 accessToken 값이 된다', () => {
+    useUserStore.getState().setAccessToken('access-token');
+    expect(useUserStore.getState().accessToken).toBe('access-token');
+  });
+  it('setJwt로 jwt 값이 된다', () => {
+    useUserStore.getState().setJwt('jwt-token');
+    expect(useUserStore.getState().jwt).toBe('jwt-token');
+  });
+  it('setExpireDate로 expireDate 값이 된다', () => {
+    const expireDate = new Date().toISOString();
+    useUserStore.getState().setExpireDate(expireDate);
+    expect(useUserStore.getState().expireDate).toBe(expireDate);
+  });
   it('clearUser로 user 값이 null', () => {
     useUserStore.getState().setUser({ userId: 1 } as LoginUserInfoDto);
     useUserStore.getState().clearUser();

--- a/frontend/content-hub-frontend/src/components/common/store/globalStateStore.ts
+++ b/frontend/content-hub-frontend/src/components/common/store/globalStateStore.ts
@@ -122,7 +122,12 @@ export const useUserStore = create<UseUserStoreType>((set) => ({
   setJwt: (jwt) => set(() => ({ jwt })),
   expireDate: null,
   setExpireDate: (expireDate) => set(() => ({ expireDate })),
-  clearUser: () => set(() => ({ user: null })),
+  clearUser: () => set(() => ({ 
+    user: null,
+    accessToken: null,
+    jwt: null,
+    expireDate: null,
+  })),
 }));
 
 /**

--- a/frontend/content-hub-frontend/src/components/common/store/globalStateStore.ts
+++ b/frontend/content-hub-frontend/src/components/common/store/globalStateStore.ts
@@ -14,6 +14,12 @@ import { persist } from 'zustand/middleware';
 type UseUserStoreType = {
   user: LoginUserInfoDto | null;
   setUser: (user: LoginUserInfoDto) => void;
+  accessToken: string | null;
+  setAccessToken: (accessToken: string) => void;
+  jwt: string | null;
+  setJwt: (jwt: string) => void;
+  expireDate: string | null;
+  setExpireDate: (expireDate: string) => void;
   clearUser: () => void;
 };
 
@@ -110,6 +116,12 @@ type UseDisplayMediaTypeMapStoreType = {
 export const useUserStore = create<UseUserStoreType>((set) => ({
   user: null,
   setUser: (user) => set(() => ({ user })),
+  accessToken: null,
+  setAccessToken: (accessToken) => set(() => ({ accessToken })),
+  jwt: null,
+  setJwt: (jwt) => set(() => ({ jwt })),
+  expireDate: null,
+  setExpireDate: (expireDate) => set(() => ({ expireDate })),
   clearUser: () => set(() => ({ user: null })),
 }));
 

--- a/frontend/content-hub-frontend/src/components/common/utils/clearUtil.test.ts
+++ b/frontend/content-hub-frontend/src/components/common/utils/clearUtil.test.ts
@@ -1,25 +1,42 @@
-import { describe, expect, it, vi } from "vitest";
-import * as globalStateStore from "../store/globalStateStore";
+import { beforeEach, describe, expect, it } from "vitest";
 import { clearUserData } from "./clearUtil";
 import { waitFor } from "@testing-library/react";
+import { useProviderStore, useUserStore } from "../store/globalStateStore";
 
 describe('clearUserData', () => {
-    it('유저정보 및 provider정보 클리어 확인', () => {
-        // 상태 클리어 함수 모킹
-        const clearUserMock = vi.fn();
-        const clearProviderMock = vi.fn();
-        vi.spyOn(globalStateStore, 'useUserStore').mockReturnValue({
-            clearUser: clearUserMock,
-        });
-        vi.spyOn(globalStateStore, 'useProviderStore').mockReturnValue({
-            clearProvider: clearProviderMock,
-        });
+    // 초기 상태 설정
+    const userInfo = { userId: 1, nickname: 'TestUser' };
+    const accessToken = 'access-token';
+    const jwt = 'jwt';
+    const expireDate = new Date().toISOString();
+    const provider = 'NAVER';
+
+    beforeEach(() => {
+        // 초기 상태 설정
+        useUserStore.getState().setUser(userInfo);
+        useUserStore.getState().setAccessToken(accessToken);
+        useUserStore.getState().setJwt(jwt);
+        useUserStore.getState().setExpireDate(expireDate);
+        useProviderStore.getState().setProvider('NAVER');
+    });
+
+    it('유저정보 및 provider정보 클리어 확인', async () => {
+        // 초기 상태 검증
+        expect(useUserStore.getState().user).toBe(userInfo)
+        expect(useUserStore.getState().accessToken).toBe(accessToken);
+        expect(useUserStore.getState().jwt).toBe(jwt);
+        expect(useUserStore.getState().expireDate).toBe(expireDate);
+        expect(useProviderStore.getState().provider).toBe(provider);
+
         // 함수 호출
         clearUserData();
         // 검증
-        waitFor(() => {
-            expect(clearUserMock).toHaveBeenCalled();
-            expect(clearProviderMock).toHaveBeenCalled();
+        await waitFor(() => {
+            expect(useUserStore.getState().user).toBeNull();
+            expect(useUserStore.getState().accessToken).toBeNull();
+            expect(useUserStore.getState().jwt).toBeNull();
+            expect(useUserStore.getState().expireDate).toBeNull();
+            expect(useProviderStore.getState().provider).toBeUndefined();
         });
     });
 });

--- a/frontend/content-hub-frontend/src/components/common/utils/clearUtil.test.ts
+++ b/frontend/content-hub-frontend/src/components/common/utils/clearUtil.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+import * as globalStateStore from "../store/globalStateStore";
+import { clearUserData } from "./clearUtil";
+import { waitFor } from "@testing-library/react";
+
+describe('clearUserData', () => {
+    it('유저정보 및 provider정보 클리어 확인', () => {
+        // 상태 클리어 함수 모킹
+        const clearUserMock = vi.fn();
+        const clearProviderMock = vi.fn();
+        vi.spyOn(globalStateStore, 'useUserStore').mockReturnValue({
+            clearUser: clearUserMock,
+        });
+        vi.spyOn(globalStateStore, 'useProviderStore').mockReturnValue({
+            clearProvider: clearProviderMock,
+        });
+        // 함수 호출
+        clearUserData();
+        // 검증
+        waitFor(() => {
+            expect(clearUserMock).toHaveBeenCalled();
+            expect(clearProviderMock).toHaveBeenCalled();
+        });
+    });
+});

--- a/frontend/content-hub-frontend/src/components/common/utils/clearUtil.ts
+++ b/frontend/content-hub-frontend/src/components/common/utils/clearUtil.ts
@@ -1,11 +1,7 @@
 import { useProviderStore, useUserStore } from '../store/globalStateStore';
 
 /**
- * 데이터를 클리어하는 함수를 정의하는 유틸 파일
- */
-
-/**
- * 유저정보, provider정보, 세션스토리지 클리어
+ * 유저정보, provider정보 클리어
  */
 export const clearUserData = () => {
   // 유저정보
@@ -16,8 +12,4 @@ export const clearUserData = () => {
   clearUser();
   // provider정보 클리어
   clearProvider();
-  // sessionStorage클리어
-  sessionStorage.removeItem('accessToken');
-  sessionStorage.removeItem('jwt');
-  sessionStorage.removeItem('expireDate');
 };

--- a/frontend/content-hub-frontend/src/components/common/utils/loginUtil.test.ts
+++ b/frontend/content-hub-frontend/src/components/common/utils/loginUtil.test.ts
@@ -8,8 +8,11 @@ import { waitFor } from "@testing-library/react";
 import * as clearUtil from './clearUtil';
 import { LoginUserResponseDto } from "@/api/data-contracts";
 import { toast } from "react-toastify";
+import * as Sentry from '@sentry/react';
 
-const Sentry = import('@sentry/react');
+vi.mock('@sentry/react', () => ({
+  setUser: vi.fn(),
+}));
 
 describe('afterLoginRedirect', () => {
     it('리다이렉트 URL이 있다면 해당 URL로 이동', () => {
@@ -88,13 +91,6 @@ describe('setLoginInfo', () => {
         vi.spyOn(globalStateStore, 'useProviderStore').mockReturnValue({
             setProvider: setProviderMock,
         });
-        // Sentry 모킹
-        const setUserSentryMock = vi.fn();
-        async function mockSentry() {
-            vi.spyOn((await Sentry).default, 'setUser').mockImplementation(setUserSentryMock);
-        }
-        mockSentry();
-
         // 함수 호출
         setLoginInfo(mockLoginInfo, provider);
         // 검증
@@ -105,7 +101,7 @@ describe('setLoginInfo', () => {
             expect(setJwtMock).toHaveBeenCalledWith(mockLoginInfo.jwt);
             expect(setExpireDateMock).toHaveBeenCalledWith(mockLoginInfo.expireDate);
             expect(setProviderMock).toHaveBeenCalledWith(provider);
-            expect(setUserSentryMock).toHaveBeenCalledWith({
+            expect(Sentry.setUser).toHaveBeenCalledWith({
                 id: mockLoginInfo.userInfo!.userId,
                 username: mockLoginInfo.userInfo!.nickname,
             });

--- a/frontend/content-hub-frontend/src/components/common/utils/loginUtil.test.ts
+++ b/frontend/content-hub-frontend/src/components/common/utils/loginUtil.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it, vi } from "vitest";
+import { NavigateFunction } from 'react-router-dom';
+import { afterLoginRedirect, loginConfirmDialog, setLoginInfo } from "./loginUtil";
+import { REDIRECT_URL } from "../constants/constants";
+import { useConfirmDialogStore } from "../store/globalStateStore";
+import * as globalStateStore from "../store/globalStateStore";
+import { waitFor } from "@testing-library/react";
+import * as clearUtil from './clearUtil';
+import { LoginUserResponseDto } from "@/api/data-contracts";
+import { toast } from "react-toastify";
+
+const Sentry = import('@sentry/react');
+
+describe('afterLoginRedirect', () => {
+    it('리다이렉트 URL이 있다면 해당 URL로 이동', () => {
+        const navigate = vi.fn() as NavigateFunction;
+        const redirectUrl = '/home/rankings';
+        sessionStorage.setItem(REDIRECT_URL, redirectUrl);
+        afterLoginRedirect(navigate);
+        expect(navigate).toHaveBeenCalledWith(redirectUrl, { replace: true });
+        expect(sessionStorage.getItem(REDIRECT_URL)).toBeNull();
+    });
+
+    it('리다이렉트 URL이 없다면 홈으로 이동', () => {
+        const navigate = vi.fn() as NavigateFunction;
+        sessionStorage.removeItem(REDIRECT_URL);
+        afterLoginRedirect(navigate);
+        expect(navigate).toHaveBeenCalledWith('/', { replace: true });
+    });
+});
+
+describe('loginConfirmDialog', () => {
+    it('로그인 확인 다이얼로그 설정 및 동작 확인', () => {
+        const navigate = vi.fn() as NavigateFunction;
+        const message = '로그인이 필요합니다.';
+        loginConfirmDialog(message, navigate);
+
+        const confirmDialogStore = useConfirmDialogStore.getState();
+        expect(confirmDialogStore.isConfirmDialogOpen).toBe(true);
+        // OK 동작 테스트
+        confirmDialogStore.onOk();
+        waitFor(() => {
+            expect(confirmDialogStore.isConfirmDialogOpen).toBe(false);
+            expect(sessionStorage.getItem(REDIRECT_URL)).toBe(location.pathname + location.search);
+            expect(navigate).toHaveBeenCalledWith('/login');
+        });
+        // Cancel 동작 테스트
+        confirmDialogStore.setIsConfirmDialogOpen(true);
+        confirmDialogStore.onCancel();
+        waitFor(() => {
+            expect(confirmDialogStore.isConfirmDialogOpen).toBe(false);
+        });
+    });
+});
+
+describe('setLoginInfo', () => {
+    // clearUserData 모킹
+    const clearUserDataMock = vi.fn();
+    // 콘솔 에러 및 토스트 메시지 모킹
+    const consoleErrorMock = vi.spyOn(console, 'error').mockImplementation(() => { });
+    const toastErrorMock = vi.spyOn(toast, 'error').mockImplementation(() => '');
+
+    it('유저 정보 및 토큰 상태 저장 확인', () => {
+        const mockLoginInfo = {
+            userInfo: {
+                userId: 1,
+                name: 'name',
+                nickname: 'nickname',
+            },
+            accessToken: 'access-token',
+            jwt: 'jwt-token',
+            expireDate: new Date().toISOString(),
+        } as LoginUserResponseDto;
+        const provider = 'NAVER';
+
+        // 상태 저장 함수 모킹
+        const setUserMock = vi.fn();
+        const setAccessTokenMock = vi.fn();
+        const setJwtMock = vi.fn();
+        const setExpireDateMock = vi.fn();
+        const setProviderMock = vi.fn();
+        vi.spyOn(globalStateStore, 'useUserStore').mockReturnValue({
+            setUser: setUserMock,
+            setAccessToken: setAccessTokenMock,
+            setJwt: setJwtMock,
+            setExpireDate: setExpireDateMock,
+        });
+        vi.spyOn(globalStateStore, 'useProviderStore').mockReturnValue({
+            setProvider: setProviderMock,
+        });
+        // Sentry 모킹
+        const setUserSentryMock = vi.fn();
+        async function mockSentry() {
+            vi.spyOn((await Sentry).default, 'setUser').mockImplementation(setUserSentryMock);
+        }
+        mockSentry();
+
+        // 함수 호출
+        setLoginInfo(mockLoginInfo, provider);
+        // 검증
+        waitFor(() => {
+            // 상태 저장 함수 호출 확인
+            expect(setUserMock).toHaveBeenCalledWith(mockLoginInfo.userInfo);
+            expect(setAccessTokenMock).toHaveBeenCalledWith(mockLoginInfo.accessToken);
+            expect(setJwtMock).toHaveBeenCalledWith(mockLoginInfo.jwt);
+            expect(setExpireDateMock).toHaveBeenCalledWith(mockLoginInfo.expireDate);
+            expect(setProviderMock).toHaveBeenCalledWith(provider);
+            expect(setUserSentryMock).toHaveBeenCalledWith({
+                id: mockLoginInfo.userInfo!.userId,
+                username: mockLoginInfo.userInfo!.nickname,
+            });
+        });
+    });
+
+    it('유저 정보가 없으면 유저 데이터 클리어 호출', () => {
+        vi.spyOn(clearUtil, 'clearUserData').mockImplementation(clearUserDataMock);
+        const mockLoginInfo = {
+            userInfo: undefined,
+            accessToken: 'access-token',
+            jwt: 'jwt-token',
+            expireDate: new Date().toISOString(),
+        } as LoginUserResponseDto;
+        const provider = 'KAKAO';
+        // 함수 호출
+        setLoginInfo(mockLoginInfo, provider);
+        // 검증
+        waitFor(() => {
+            expect(clearUserDataMock).toHaveBeenCalled();
+            expect(consoleErrorMock).toHaveBeenCalledWith('로그인 정보가 불완전합니다: ', mockLoginInfo);
+            expect(toastErrorMock).toHaveBeenCalledWith('로그인 정보가 불완전합니다. 다시 로그인 해주세요.', {
+                toastId: 'incompleteLoginInfo',
+            });
+        });
+    });
+
+    it('액세스 토큰이 없으면 유저 데이터 클리어 호출', () => {
+        vi.spyOn(clearUtil, 'clearUserData').mockImplementation(clearUserDataMock);
+        const mockLoginInfo = {
+            userInfo: {
+                userId: 1,
+                name: 'name',
+                nickname: 'nickname',
+            },
+            accessToken: undefined,
+            jwt: 'jwt-token',
+            expireDate: new Date().toISOString(),
+        } as LoginUserResponseDto;
+        const provider = 'KAKAO';
+        // 함수 호출
+        setLoginInfo(mockLoginInfo, provider);
+        // 검증
+        waitFor(() => {
+            expect(clearUserDataMock).toHaveBeenCalled();
+            expect(consoleErrorMock).toHaveBeenCalledWith('로그인 정보가 불완전합니다: ', mockLoginInfo);
+            expect(toastErrorMock).toHaveBeenCalledWith('로그인 정보가 불완전합니다. 다시 로그인 해주세요.', {
+                toastId: 'incompleteLoginInfo',
+            });
+        });
+    });
+
+    it('jwt가 없으면 유저 데이터 클리어 호출', () => {
+        vi.spyOn(clearUtil, 'clearUserData').mockImplementation(clearUserDataMock);
+        const mockLoginInfo = {
+            userInfo: {
+                userId: 1,
+                name: 'name',
+                nickname: 'nickname',
+            },
+            accessToken: 'access-token',
+            jwt: undefined,
+            expireDate: new Date().toISOString(),
+        } as LoginUserResponseDto;
+        const provider = 'KAKAO';
+        // 함수 호출
+        setLoginInfo(mockLoginInfo, provider);
+        // 검증
+        waitFor(() => {
+            expect(clearUserDataMock).toHaveBeenCalled();
+            expect(consoleErrorMock).toHaveBeenCalledWith('로그인 정보가 불완전합니다: ', mockLoginInfo);
+            expect(toastErrorMock).toHaveBeenCalledWith('로그인 정보가 불완전합니다. 다시 로그인 해주세요.', {
+                toastId: 'incompleteLoginInfo',
+            });
+        });
+    });
+
+    it('만료시각이 없으면 유저 데이터 클리어 호출', () => {        
+        vi.spyOn(clearUtil, 'clearUserData').mockImplementation(clearUserDataMock);
+        const mockLoginInfo = {
+            userInfo: {
+                userId: 1,
+                name: 'name',
+                nickname: 'nickname',
+            },
+            accessToken: 'access-token',
+            jwt: 'jwt-token',
+            expireDate: undefined,
+        } as LoginUserResponseDto;
+        const provider = 'KAKAO';
+        // 함수 호출
+        setLoginInfo(mockLoginInfo, provider);
+        // 검증
+        waitFor(() => {
+            expect(clearUserDataMock).toHaveBeenCalled();
+            expect(consoleErrorMock).toHaveBeenCalledWith('로그인 정보가 불완전합니다: ', mockLoginInfo);
+            expect(toastErrorMock).toHaveBeenCalledWith('로그인 정보가 불완전합니다. 다시 로그인 해주세요.', {
+                toastId: 'incompleteLoginInfo',
+            });
+        });
+    });
+});

--- a/frontend/content-hub-frontend/src/components/common/utils/loginUtil.test.ts
+++ b/frontend/content-hub-frontend/src/components/common/utils/loginUtil.test.ts
@@ -1,18 +1,47 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { NavigateFunction } from 'react-router-dom';
 import { afterLoginRedirect, loginConfirmDialog, setLoginInfo } from "./loginUtil";
 import { REDIRECT_URL } from "../constants/constants";
-import { useConfirmDialogStore } from "../store/globalStateStore";
-import * as globalStateStore from "../store/globalStateStore";
+import { useConfirmDialogStore, useProviderStore, useUserStore } from "../store/globalStateStore";
 import { waitFor } from "@testing-library/react";
 import * as clearUtil from './clearUtil';
 import { LoginUserResponseDto } from "@/api/data-contracts";
 import { toast } from "react-toastify";
 import * as Sentry from '@sentry/react';
+import { act } from "react";
 
 vi.mock('@sentry/react', () => ({
-  setUser: vi.fn(),
+    setUser: vi.fn(),
 }));
+
+vi.mock('@components/common/store/globalStateStore', async () => {
+    const actual = await vi.importActual('@components/common/store/globalStateStore');
+
+    const setUserMock = vi.fn();
+    const setAccessTokenMock = vi.fn();
+    const setJwtMock = vi.fn()
+    const setExpireDateMock = vi.fn();
+    const setProviderMock = vi.fn();
+
+    return {
+        ...actual,
+        useUserStore: {
+            getState: vi.fn().mockReturnValue({
+                setUser: setUserMock,
+                setAccessToken: setAccessTokenMock,
+                setJwt: setJwtMock,
+                setExpireDate: setExpireDateMock,
+            })
+        },
+        useProviderStore: {
+            getState: vi.fn().mockReturnValue({
+                setProvider: setProviderMock,
+            }),
+        },
+    };
+});
+
+afterEach(() => sessionStorage.clear());
 
 describe('afterLoginRedirect', () => {
     it('리다이렉트 URL이 있다면 해당 URL로 이동', () => {
@@ -33,25 +62,31 @@ describe('afterLoginRedirect', () => {
 });
 
 describe('loginConfirmDialog', () => {
-    it('로그인 확인 다이얼로그 설정 및 동작 확인', () => {
+    it('로그인 확인 다이얼로그 설정 및 동작 확인', async () => {
         const navigate = vi.fn() as NavigateFunction;
         const message = '로그인이 필요합니다.';
+
+        // 함수 호출
         loginConfirmDialog(message, navigate);
 
         const confirmDialogStore = useConfirmDialogStore.getState();
         expect(confirmDialogStore.isConfirmDialogOpen).toBe(true);
         // OK 동작 테스트
-        confirmDialogStore.onOk();
-        waitFor(() => {
-            expect(confirmDialogStore.isConfirmDialogOpen).toBe(false);
+        act(() => {
+            confirmDialogStore.onOk();
+        });
+        await waitFor(() => {
+            expect(useConfirmDialogStore.getState().isConfirmDialogOpen).toBe(false); // getState()를 다시 호출하여 최신 상태를 확인
             expect(sessionStorage.getItem(REDIRECT_URL)).toBe(location.pathname + location.search);
             expect(navigate).toHaveBeenCalledWith('/login');
         });
         // Cancel 동작 테스트
         confirmDialogStore.setIsConfirmDialogOpen(true);
-        confirmDialogStore.onCancel();
-        waitFor(() => {
-            expect(confirmDialogStore.isConfirmDialogOpen).toBe(false);
+        act(() => {
+            confirmDialogStore.onCancel();
+        });
+        await waitFor(() => {
+            expect(useConfirmDialogStore.getState().isConfirmDialogOpen).toBe(false); // getState()를 다시 호출하여 최신 상태를 확인
         });
     });
 });
@@ -63,7 +98,7 @@ describe('setLoginInfo', () => {
     const consoleErrorMock = vi.spyOn(console, 'error').mockImplementation(() => { });
     const toastErrorMock = vi.spyOn(toast, 'error').mockImplementation(() => '');
 
-    it('유저 정보 및 토큰 상태 저장 확인', () => {
+    it('유저 정보 및 토큰 상태 저장 확인', async () => {
         const mockLoginInfo = {
             userInfo: {
                 userId: 1,
@@ -76,31 +111,18 @@ describe('setLoginInfo', () => {
         } as LoginUserResponseDto;
         const provider = 'NAVER';
 
-        // 상태 저장 함수 모킹
-        const setUserMock = vi.fn();
-        const setAccessTokenMock = vi.fn();
-        const setJwtMock = vi.fn();
-        const setExpireDateMock = vi.fn();
-        const setProviderMock = vi.fn();
-        vi.spyOn(globalStateStore, 'useUserStore').mockReturnValue({
-            setUser: setUserMock,
-            setAccessToken: setAccessTokenMock,
-            setJwt: setJwtMock,
-            setExpireDate: setExpireDateMock,
-        });
-        vi.spyOn(globalStateStore, 'useProviderStore').mockReturnValue({
-            setProvider: setProviderMock,
-        });
         // 함수 호출
-        setLoginInfo(mockLoginInfo, provider);
+        await setLoginInfo(mockLoginInfo, provider);
         // 검증
-        waitFor(() => {
+        await waitFor(() => {
+            const userStoreState = useUserStore.getState();
+            const providerStoreState = useProviderStore.getState();
             // 상태 저장 함수 호출 확인
-            expect(setUserMock).toHaveBeenCalledWith(mockLoginInfo.userInfo);
-            expect(setAccessTokenMock).toHaveBeenCalledWith(mockLoginInfo.accessToken);
-            expect(setJwtMock).toHaveBeenCalledWith(mockLoginInfo.jwt);
-            expect(setExpireDateMock).toHaveBeenCalledWith(mockLoginInfo.expireDate);
-            expect(setProviderMock).toHaveBeenCalledWith(provider);
+            expect(userStoreState.setUser).toHaveBeenCalledWith(mockLoginInfo.userInfo);
+            expect(userStoreState.setAccessToken).toHaveBeenCalledWith(mockLoginInfo.accessToken);
+            expect(userStoreState.setJwt).toHaveBeenCalledWith(mockLoginInfo.jwt);
+            expect(userStoreState.setExpireDate).toHaveBeenCalledWith(mockLoginInfo.expireDate);
+            expect(providerStoreState.setProvider).toHaveBeenCalledWith(provider);
             expect(Sentry.setUser).toHaveBeenCalledWith({
                 id: mockLoginInfo.userInfo!.userId,
                 username: mockLoginInfo.userInfo!.nickname,
@@ -108,7 +130,7 @@ describe('setLoginInfo', () => {
         });
     });
 
-    it('유저 정보가 없으면 유저 데이터 클리어 호출', () => {
+    it('유저 정보가 없으면 유저 데이터 클리어 호출', async () => {
         vi.spyOn(clearUtil, 'clearUserData').mockImplementation(clearUserDataMock);
         const mockLoginInfo = {
             userInfo: undefined,
@@ -118,18 +140,24 @@ describe('setLoginInfo', () => {
         } as LoginUserResponseDto;
         const provider = 'KAKAO';
         // 함수 호출
-        setLoginInfo(mockLoginInfo, provider);
+        await setLoginInfo(mockLoginInfo, provider);
         // 검증
-        waitFor(() => {
+        await waitFor(() => {
             expect(clearUserDataMock).toHaveBeenCalled();
-            expect(consoleErrorMock).toHaveBeenCalledWith('로그인 정보가 불완전합니다: ', mockLoginInfo);
+            expect(consoleErrorMock).toHaveBeenCalledWith('로그인 정보가 불완전합니다.', {
+                hasUserInfo: false,
+                hasAccessToken: true,
+                hasJwt: true,
+                hasExpireDate: true,
+                userId: undefined,
+            });
             expect(toastErrorMock).toHaveBeenCalledWith('로그인 정보가 불완전합니다. 다시 로그인 해주세요.', {
                 toastId: 'incompleteLoginInfo',
             });
         });
     });
 
-    it('액세스 토큰이 없으면 유저 데이터 클리어 호출', () => {
+    it('액세스 토큰이 없으면 유저 데이터 클리어 호출', async () => {
         vi.spyOn(clearUtil, 'clearUserData').mockImplementation(clearUserDataMock);
         const mockLoginInfo = {
             userInfo: {
@@ -143,18 +171,24 @@ describe('setLoginInfo', () => {
         } as LoginUserResponseDto;
         const provider = 'KAKAO';
         // 함수 호출
-        setLoginInfo(mockLoginInfo, provider);
+        await setLoginInfo(mockLoginInfo, provider);
         // 검증
-        waitFor(() => {
+        await waitFor(() => {
             expect(clearUserDataMock).toHaveBeenCalled();
-            expect(consoleErrorMock).toHaveBeenCalledWith('로그인 정보가 불완전합니다: ', mockLoginInfo);
+            expect(consoleErrorMock).toHaveBeenCalledWith('로그인 정보가 불완전합니다.', {
+                hasUserInfo: true,
+                hasAccessToken: false,
+                hasJwt: true,
+                hasExpireDate: true,
+                userId: mockLoginInfo.userInfo?.userId,
+            });
             expect(toastErrorMock).toHaveBeenCalledWith('로그인 정보가 불완전합니다. 다시 로그인 해주세요.', {
                 toastId: 'incompleteLoginInfo',
             });
         });
     });
 
-    it('jwt가 없으면 유저 데이터 클리어 호출', () => {
+    it('jwt가 없으면 유저 데이터 클리어 호출', async () => {
         vi.spyOn(clearUtil, 'clearUserData').mockImplementation(clearUserDataMock);
         const mockLoginInfo = {
             userInfo: {
@@ -168,18 +202,24 @@ describe('setLoginInfo', () => {
         } as LoginUserResponseDto;
         const provider = 'KAKAO';
         // 함수 호출
-        setLoginInfo(mockLoginInfo, provider);
+        await setLoginInfo(mockLoginInfo, provider);
         // 검증
-        waitFor(() => {
+        await waitFor(() => {
             expect(clearUserDataMock).toHaveBeenCalled();
-            expect(consoleErrorMock).toHaveBeenCalledWith('로그인 정보가 불완전합니다: ', mockLoginInfo);
+            expect(consoleErrorMock).toHaveBeenCalledWith('로그인 정보가 불완전합니다.', {
+                hasUserInfo: true,
+                hasAccessToken: true,
+                hasJwt: false,
+                hasExpireDate: true,
+                userId: mockLoginInfo.userInfo?.userId,
+            });
             expect(toastErrorMock).toHaveBeenCalledWith('로그인 정보가 불완전합니다. 다시 로그인 해주세요.', {
                 toastId: 'incompleteLoginInfo',
             });
         });
     });
 
-    it('만료시각이 없으면 유저 데이터 클리어 호출', () => {        
+    it('만료시각이 없으면 유저 데이터 클리어 호출', async () => {
         vi.spyOn(clearUtil, 'clearUserData').mockImplementation(clearUserDataMock);
         const mockLoginInfo = {
             userInfo: {
@@ -193,11 +233,17 @@ describe('setLoginInfo', () => {
         } as LoginUserResponseDto;
         const provider = 'KAKAO';
         // 함수 호출
-        setLoginInfo(mockLoginInfo, provider);
+        await setLoginInfo(mockLoginInfo, provider);
         // 검증
-        waitFor(() => {
+        await waitFor(() => {
             expect(clearUserDataMock).toHaveBeenCalled();
-            expect(consoleErrorMock).toHaveBeenCalledWith('로그인 정보가 불완전합니다: ', mockLoginInfo);
+            expect(consoleErrorMock).toHaveBeenCalledWith('로그인 정보가 불완전합니다.', {
+                hasUserInfo: true,
+                hasAccessToken: true,
+                hasJwt: true,
+                hasExpireDate: false,
+                userId: mockLoginInfo.userInfo?.userId,
+            });
             expect(toastErrorMock).toHaveBeenCalledWith('로그인 정보가 불완전합니다. 다시 로그인 해주세요.', {
                 toastId: 'incompleteLoginInfo',
             });

--- a/frontend/content-hub-frontend/src/components/common/utils/loginUtil.ts
+++ b/frontend/content-hub-frontend/src/components/common/utils/loginUtil.ts
@@ -8,6 +8,7 @@ import {
 } from '../store/globalStateStore';
 import { LoginUserResponseDto } from '@/api/data-contracts';
 import { clearUserData } from './clearUtil';
+import { toast } from 'react-toastify';
 
 // Sentry 동적 import
 const Sentry = import('@sentry/react');
@@ -72,20 +73,24 @@ export const setLoginInfo = async (
   provider: string
 ) => {
   // 로그인 정보가 없으면 유저정보 클리어 후 종료
-  if (!loginInfo.userInfo) {
+  if (!loginInfo.userInfo || !loginInfo.accessToken || !loginInfo.jwt || !loginInfo.expireDate) {
     clearUserData();
+    console.error('로그인 정보가 불완전합니다: ', loginInfo);
+    toast.error('로그인 정보가 불완전합니다. 다시 로그인 해주세요.', {
+      toastId: 'incompleteLoginInfo',
+    });
     return;
   }
-  // 유저정보를 전역상태저장
+  // 유저정보 전역 상태 저장
   useUserStore.getState().setUser(loginInfo.userInfo);
-  // provider 전역상태저장
+  // 액세스 토큰 전역 상태 저장
+  useUserStore.getState().setAccessToken(loginInfo.accessToken);
+  // JWT 전역 상태 저장
+  useUserStore.getState().setJwt(loginInfo.jwt);
+  // 만료시각 전역 상태 저장
+  useUserStore.getState().setExpireDate(loginInfo.expireDate);
+  // provider 전역 상태 저장
   useProviderStore.getState().setProvider(provider as LOGIN_PROVIDER);
-  // 액세스 토큰을 sessionStorage에 저장
-  sessionStorage.setItem('accessToken', loginInfo.accessToken!);
-  // JWT를 sessionStorage에 저장
-  sessionStorage.setItem('jwt', loginInfo.jwt!);
-  // 만료시각을 sessionStorage에 저장
-  sessionStorage.setItem('expireDate', loginInfo.expireDate!);
   // Sentry에 유저 정보 설정
   (await Sentry).setUser({
     id: loginInfo.userInfo.userId,

--- a/frontend/content-hub-frontend/src/components/common/utils/loginUtil.ts
+++ b/frontend/content-hub-frontend/src/components/common/utils/loginUtil.ts
@@ -75,7 +75,13 @@ export const setLoginInfo = async (
   // 로그인 정보가 없으면 유저정보 클리어 후 종료
   if (!loginInfo.userInfo || !loginInfo.accessToken || !loginInfo.jwt || !loginInfo.expireDate) {
     clearUserData();
-    console.error('로그인 정보가 불완전합니다: ', loginInfo);
+    console.error('로그인 정보가 불완전합니다.', {
+      hasUserInfo: !!loginInfo.userInfo,
+      hasAccessToken: !!loginInfo.accessToken,
+      hasJwt: !!loginInfo.jwt,
+      hasExpireDate: !!loginInfo.expireDate,
+      userId: loginInfo.userInfo?.userId,
+    });
     toast.error('로그인 정보가 불완전합니다. 다시 로그인 해주세요.', {
       toastId: 'incompleteLoginInfo',
     });

--- a/frontend/content-hub-frontend/src/components/features/login/Logout.tsx
+++ b/frontend/content-hub-frontend/src/components/features/login/Logout.tsx
@@ -20,8 +20,8 @@ export const Logout = () => {
   const navigate = useNavigate();
   // provider 전역 상태 저장 훅
   const { provider } = useProviderStore();
-  // user 전역 상태 저장 훅
-  const { user } = useUserStore();
+  // user, accessToken 전역 상태 저장 훅
+  const { user, accessToken } = useUserStore();
   // 로그인 API 인스턴스 생성
   const loginApi = new LoginApi();
 
@@ -39,8 +39,6 @@ export const Logout = () => {
         const providerId = user!.id!;
         // 유저 ID
         const userId = user!.userId!;
-        // 접근토큰 취득
-        const accessToken = sessionStorage.getItem('accessToken');
         // 접근토큰이나 provider가 존재하지 않는 경우는 처리 종료
         if (!accessToken || !provider) {
           return;

--- a/frontend/content-hub-frontend/src/components/features/login/useKakaoLogin.ts
+++ b/frontend/content-hub-frontend/src/components/features/login/useKakaoLogin.ts
@@ -49,7 +49,7 @@ export const useKakaoLogin = () => {
     });
     const loginInfo = response.data;
     // 로그인 정보를 전역 상태에 저장
-    setLoginInfo(loginInfo, LOGIN_PROVIDER.KAKAO);
+    await setLoginInfo(loginInfo, LOGIN_PROVIDER.KAKAO);
     return loginInfo;
   };
 
@@ -66,14 +66,17 @@ export const useKakaoLogin = () => {
       return;
     }
     // 카카오 로그인 인증 및 유저 정보 조회 API 호출
-    getKakaoLoginInfo(code).catch((err) => {
-      console.error('카카오 로그인 실패', err);
-      toast.error(t('error.loginError'), {
-        toastId: 'kakaoLoginError',
+    getKakaoLoginInfo(code)
+      .then(() => {
+        // 리다이렉트 URL이 있다면 해당 URL로 이동
+        afterLoginRedirect(navigate);
+      })
+      .catch((err) => {
+        console.error('카카오 로그인 실패', err);
+        toast.error(t('error.loginError'), {
+          toastId: 'kakaoLoginError',
+        });
+        navigate('/login');
       });
-      navigate('/login');
-    });
-    // 리다이렉트 URL이 있다면 해당 URL로 이동
-    afterLoginRedirect(navigate);
   }, []);
 };

--- a/frontend/content-hub-frontend/src/components/features/login/useNaverLogin.ts
+++ b/frontend/content-hub-frontend/src/components/features/login/useNaverLogin.ts
@@ -49,7 +49,7 @@ export const useNaverLogin = () => {
     });
     const loginInfo = response.data;
     // 로그인 정보를 전역 상태에 저장
-    setLoginInfo(loginInfo, LOGIN_PROVIDER.NAVER);
+    await setLoginInfo(loginInfo, LOGIN_PROVIDER.NAVER);
     return loginInfo;
   };
 
@@ -71,14 +71,17 @@ export const useNaverLogin = () => {
       return;
     }
     // 네이버 로그인 인증 및 유저 정보 조회 API 요청
-    getNaverLoginInfo(code, state).catch((err) => {
-      console.error('네이버 로그인 실패', err);
-      toast.error(t('error.loginError'), {
-        toastId: 'naverLoginError',
+    getNaverLoginInfo(code, state)
+      .then(() => {
+        // 리다이렉트 URL이 있다면 해당 URL로 이동
+        afterLoginRedirect(navigate);
+      })
+      .catch((err) => {
+        console.error('네이버 로그인 실패', err);
+        toast.error(t('error.loginError'), {
+          toastId: 'naverLoginError',
+        });
+        navigate('/login');
       });
-      navigate('/login');
-    });
-    // 리다이렉트 URL이 있다면 해당 URL로 이동
-    afterLoginRedirect(navigate);
   }, []);
 };


### PR DESCRIPTION
## 관련 이슈
Closes #26 

## 변경 내용
### 공통
1. Git
- .gitignore에 "/backend/redis/data/"등록 (chore)
2. 인프라
- docker-compose.override.yml: 각 컨테이너(db,redis,backend,frontend) environment에 타임존(TZ=Asia/Seoul) 설정 (feat)
- nginx.conf: 헤더에 CSP(Content-Security-Policy), HSTS(Strict-Transport-Security) 설정 추가 (feat)

### 프론트엔드
1. 공통
- globalStateStore.ts: userStore.clearUser 실행 시 accessToken, jwt, expireDate도 같이 클리어 하도록 수정 (fix)
2. 로그인
- accessToken, jwt, expireDate를, sessionStorage에서 Zustand 전역 변수 메모리에 보존하도록 변경하여 XSS 취약점 개선 (feat)

## 테스트 완료 항목
- [x] 로컬 환경 테스트
- [x] 기존 기능 영향 없음 확인

## 배포 후 검증 계획
1. 로그인이 문제 없이 실행 되는지 확인
2. 브라우저 개발자 모드(F12) → Application 탭 → Session Storage에 accessToken, jwt, expireDate가 없는 것을 확인

## 스크린샷
- 로그인 정상 실행 및 세션 영역에 accessToken, jwt, expireDate가 없는 것을 확인
<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/6922002c-a26f-4ac1-adaf-7a1150cabaa5" />

- 응답 헤더에 Content-Security-Policy, Strict-Transport-Security 확인
<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/2ab6bd5b-98a2-4a8d-ad75-abda1ba9cf20" />
